### PR TITLE
Support for running tests against product repositories

### DIFF
--- a/.github/scripts/prepare-local-server.sh
+++ b/.github/scripts/prepare-local-server.sh
@@ -1,8 +1,15 @@
 #!/bin/bash -e
 
 mkdir keycloak-dist
+WGET_ARGS=
 
-if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
+if [ -n "$PRODUCT" ] && [ "$PRODUCT" == "true" ] && [ -n "$PRODUCT_BUNDLE_URL" ]; then
+  echo "Downloading product bits from $PRODUCT_BUNDLE_URL"
+  URL=$PRODUCT_BUNDLE_URL;
+  if [ -n "$SKIP_SSL_VALIDATIONS" ] && [ "$SKIP_SSL_VALIDATIONS" == "true" ]; then
+    WGET_ARGS="--no-check-certificate";
+  fi
+elif [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
   VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
   echo "Using corresponding Keycloak version: $VERSION"
   URL="https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz"
@@ -11,5 +18,5 @@ else
   URL="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.tar.gz"
 fi
 
-wget -q -O keycloak-dist.tar.gz "$URL"
+wget -q -O keycloak-dist.tar.gz "$URL" $WGET_ARGS
 tar xzf keycloak-dist.tar.gz --strip-components=1 -C keycloak-dist

--- a/.github/scripts/run-tests.sh
+++ b/.github/scripts/run-tests.sh
@@ -13,15 +13,11 @@ run_tests() {
   echo "*****************************************"
   if [ -n "$PRODUCT" ] && [ "$PRODUCT" == "true" ]; then
     args="$args -s $PRODUCT_MVN_SETTINGS  -Dmaven.repo.local=$PRODUCT_MVN_REPO"
-    if [ "$module" == "extension/action-token-authenticator" ] \
-        || [ "$module" == "extension/action-token-required-action" ] \
-        || [ "$module" == "extension/event-listener-sysout" ] \
-        || [ "$module" == "extension/event-store-mem" ] \
-        || [ "$module" == "extension/extend-account-console" ]; then
-      return 0
-    fi
   else
     args="$args -s .github/maven-settings.xml"
+  fi
+  if [ -n "$SKIP_SSL_VALIDATIONS" ] && [ "$SKIP_SSL_VALIDATIONS" == "true" ]; then
+    args="$args -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -Dmaven.wagon.http.ssl.ignore.validity.dates=true"
   fi
   if [ -n "$CHROMEWEBDRIVER" ]; then
     args="$args -Dwebdriver.chrome.driver=$CHROMEWEBDRIVER/chromedriver"
@@ -30,6 +26,7 @@ run_tests() {
   fi
   args="$args -D$module"
   log_file=${module////_}.log
+  echo "Maven arguments when running tests: $args";
   if ! mvn clean install -Dnightly $args -B 2>&1 | tee test-logs/$log_file; then
     tests_with_errors+=("$module")
   fi

--- a/.github/scripts/start-local-server.sh
+++ b/.github/scripts/start-local-server.sh
@@ -9,7 +9,18 @@ if [ "$1" = "extension" ]; then
   echo "Adding default providers when starting Keycloak server";
 
   if [ "$1" == "extension" ]; then
-    mvn -Dextension -DskipTests -B -Dnightly clean package
+    args="${*:2}"
+    if [ -n "$PRODUCT" ] && [ "$PRODUCT" == "true" ]; then
+      args="$args -s $PRODUCT_MVN_SETTINGS  -Dmaven.repo.local=$PRODUCT_MVN_REPO"
+    else
+      args="$args -s .github/maven-settings.xml"
+    fi
+    if [ -n "$SKIP_SSL_VALIDATIONS" ] && [ "$SKIP_SSL_VALIDATIONS" == "true" ]; then
+      args="$args -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true -Dmaven.wagon.http.ssl.ignore.validity.dates=true"
+    fi
+    echo "Maven arguments when building extension quickstarts: $args";
+
+    mvn -Dextension -DskipTests -B -Dnightly $args clean package
     cp extension/user-storage-simple/target/user-storage-properties-example.jar $dist/providers
     cp extension/user-storage-jpa/conf/quarkus.properties $dist/conf
     cp extension/user-storage-jpa/target/user-storage-jpa-example.jar $dist/providers

--- a/README-product-testing.md
+++ b/README-product-testing.md
@@ -1,0 +1,43 @@
+Product testing notes
+---------------------
+
+Here are some notes for how to test this quickstart with the Red Hat build of Keycloak from the product repository, which is not yet published online.
+This repository can be on the URL, which is private and does not refer to the SSL certificate signed by any well-known root certificate authority and hence some more tweaks might be 
+needed due to this.
+
+Here some commands, which you may need to update according to your environment
+
+```
+export VERSION=<replace with the proper version>
+
+./set-version.sh $VERSION
+
+export PRODUCT=true
+
+# Needed on some environments (usually newer versions of Ubuntu or Debian) because of running tests with PhantomJS. See for example https://github.com/nodejs/node/issues/43132 for the details.
+export OPENSSL_CONF=/dev/null
+
+# Seems to be needed on maven repository on the "https" URL, which is not signed by well-known root CA
+export SKIP_SSL_VALIDATIONS=true
+
+# Needed on my laptop to be able to run the tests with latest chrome version. It must point to the directory with the file "chromedriver" inside it
+export CHROMEWEBDRIVER=/<somedir>/chromedriver-linux64-119.0.6045.105
+
+# Replace with the URL from which the product would be downloaded
+export PRODUCT_BUNDLE_URL=<maven-repository-url>/org/keycloak/keycloak-quarkus-dist/$VERSION/keycloak-quarkus-dist-$VERSION.tar.gz
+
+# Replace with the settings file containing references to prod repositories
+export PRODUCT_MVN_SETTINGS=/home/<yourhome>/.m2/settings-prod-rhbk.xml
+
+# Set to your local maven repository or different repository (if you prefer product bits to not be available in your local maven repo)
+export PRODUCT_MVN_REPO=/home/<yourhome>/.m2/repository
+
+.github/scripts/prepare-local-server.sh
+.github/scripts/start-local-server.sh extension
+
+.github/scripts/run-tests.sh extension
+.github/scripts/run-tests.sh spring
+.github/scripts/run-tests.sh js
+.github/scripts/run-tests.sh nodejs
+.github/scripts/run-tests.sh jakarta
+```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ to the version of the chrome browser used. In case of the issues, see [Chrome pa
 correct chrome driver version for your Chrome browser. Then add system property `webdriver.chrome.driver` when running the tests according to chrome version
 and add whole path to the chrome driver. For instance something like `-Dwebdriver.chrome.driver=/somedir/chromedriver-linux64-119.0.6045.105/chromedriver`.
 
+### Product testing
+
+Please refer to [README for product testing](README-product-testing.md).
+
 ## Help and Documentation
 
 * [Documentation](https://www.keycloak.org/documentation.html)

--- a/extension/user-storage-jpa/pom.xml
+++ b/extension/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extension/user-storage-simple/pom.xml
+++ b/extension/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/jaxrs-resource-server/pom.xml
+++ b/jakarta/jaxrs-resource-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jakarta-servlet-authz-client</artifactId>

--- a/js/spa/package-lock.json
+++ b/js/spa/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "spa",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^21.1.1",
+        "@keycloak/keycloak-admin-client": "^22.0.5",
         "express": "^4.18.2",
         "string-replace-middleware": "^1.0.2"
       },
@@ -15,17 +15,17 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-21.1.1.tgz",
-      "integrity": "sha512-pXlcS+QU7wzcVG04jVoJieb+/j3W+UgIajd6bqoPPWGIdV1vlVnvKZw0fK8VGbhc80TSqg/9hJbxy02tfg8i5w==",
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.5.tgz",
+      "integrity": "sha512-/4unlIhZ2WDFeWltrFJCasPjrmlQ6kJ/JqntQSb1txqgVd82qITaOu1Ya9rP1fB4E99/dE8Cgmat14GviZF3mA==",
       "dependencies": {
-        "camelize-ts": "^2.5.0",
+        "camelize-ts": "^3.0.0",
         "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
         "url-template": "^3.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/camelize-ts": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.5.0.tgz",
-      "integrity": "sha512-ERaOJadw+ID9MuKGeTOF1kQOb/zZIv6Vkt44kFYZraiAFiZU6E3TwnJebp8jofsW/hDxME/U63lFdNKIkSqijw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-3.0.0.tgz",
+      "integrity": "sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "string-replace-middleware": "^1.0.2",
-    "@keycloak/keycloak-admin-client": "^21.1.1"
+    "@keycloak/keycloak-admin-client": "^22.0.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.33.0"

--- a/nodejs/resource-server/package-lock.json
+++ b/nodejs/resource-server/package-lock.json
@@ -6,26 +6,26 @@
     "": {
       "name": "keycloak-resource-server",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "^21.1.1",
+        "@keycloak/keycloak-admin-client": "^22.0.5",
         "express": "^4.18.2",
-        "keycloak-connect": "^21.1.1"
+        "keycloak-connect": "^22.0.5"
       },
       "devDependencies": {
         "keycloak-request-token": "^0.1.0"
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-21.1.1.tgz",
-      "integrity": "sha512-pXlcS+QU7wzcVG04jVoJieb+/j3W+UgIajd6bqoPPWGIdV1vlVnvKZw0fK8VGbhc80TSqg/9hJbxy02tfg8i5w==",
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.5.tgz",
+      "integrity": "sha512-/4unlIhZ2WDFeWltrFJCasPjrmlQ6kJ/JqntQSb1txqgVd82qITaOu1Ya9rP1fB4E99/dE8Cgmat14GviZF3mA==",
       "dependencies": {
-        "camelize-ts": "^2.5.0",
+        "camelize-ts": "^3.0.0",
         "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
         "url-template": "^3.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@testim/chrome-version": {
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/camelize-ts": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.5.0.tgz",
-      "integrity": "sha512-ERaOJadw+ID9MuKGeTOF1kQOb/zZIv6Vkt44kFYZraiAFiZU6E3TwnJebp8jofsW/hDxME/U63lFdNKIkSqijw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-3.0.0.tgz",
+      "integrity": "sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -709,10 +709,9 @@
       }
     },
     "node_modules/keycloak-connect": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-21.1.1.tgz",
-      "integrity": "sha512-FFLhsnXjo+OmzMJpFhHcTjLHLwT18aZi1hJj/TLwXjijyHUFDBdVyD+uF7Hspcs4A4s00xwteAqkQGMlFQa6Yw==",
-      "deprecated": "This package is deprecated and will be removed in the future. We will shortly provide more details on removal date, and recommended alternatives.",
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-connect/-/keycloak-connect-22.0.5.tgz",
+      "integrity": "sha512-3aTU3m/hA9to6NhC1pLK6Rv/9zqJuvmX5J5C4LkKXF64ejQk/nlUnPw2hrBky+s6eJneFQ/sCWf4OSNGsenAYw==",
       "dependencies": {
         "jwk-to-pem": "^2.0.0"
       },

--- a/nodejs/resource-server/package.json
+++ b/nodejs/resource-server/package.json
@@ -8,9 +8,9 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "^21.1.1",
+    "@keycloak/keycloak-admin-client": "^22.0.5",
     "express": "^4.18.2",
-    "keycloak-connect": "^21.1.1"
+    "keycloak-connect": "^22.0.5"
   },
   "devDependencies": {
     "keycloak-request-token": "^0.1.0"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>22.0.6.redhat-00002</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>

--- a/spring/rest-authz-resource-server/pom.xml
+++ b/spring/rest-authz-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This PR adds possibility to test with product repositories with the Red Hat build of Keycloak from the product repository, which is not yet published online.

NOTE: This PR adds support to skip ssl certificate validations for some maven repositories. The better option to avoid that might be to have SSL certificates available for the particular repositories if possible.