### PR TITLE
Update to use RHBK 22 adapters. Updating Keycloak version

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -26,7 +26,7 @@
             <updatePolicy>never</updatePolicy>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
             <updatePolicy>never</updatePolicy>
           </snapshots>
         </repository>
@@ -42,16 +42,53 @@
             <updatePolicy>never</updatePolicy>
           </releases>
           <snapshots>
-            <enabled>true</enabled>
+            <enabled>false</enabled>
             <updatePolicy>never</updatePolicy>
           </snapshots>
         </pluginRepository>
       </pluginRepositories>
     </profile>
+
+    <profile>
+      <id>redhat-ga-repository</id>
+      <repositories>
+        <repository>
+          <id>redhat-ga-repository-group</id>
+          <name>RedHat GA Repository Group</name>
+          <url>https://maven.repository.redhat.com/ga/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>redhat-ga-repository-group</id>
+          <name>RedHat GA Repository Group</name>
+          <url>https://maven.repository.redhat.com/ga/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
   </profiles>
 
   <activeProfiles>
-    <activeProfile>jboss-public-repository</activeProfile>
+    <activeProfile>redhat-ga-repository</activeProfile>
   </activeProfiles>
 
 </settings>

--- a/.github/scripts/prepare-local-server.sh
+++ b/.github/scripts/prepare-local-server.sh
@@ -3,9 +3,12 @@
 mkdir keycloak-dist
 
 if [[ ( -n "$GITHUB_BASE_REF" &&  "$GITHUB_BASE_REF" == "latest" ) ]] || [[ ( -n "$QUICKSTART_BRANCH" && "$QUICKSTART_BRANCH" != "main" ) ]]; then
-  VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
-  echo "Using corresponding Keycloak version: $VERSION"
-  URL="https://github.com/keycloak/keycloak/releases/download/${VERSION}/keycloak-${VERSION}.tar.gz"
+  KEYCLOAK_SERVER_VERSION=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml)
+fi
+
+if [[ -n "$KEYCLOAK_SERVER_VERSION" ]]; then
+  echo "Using corresponding Keycloak version: $KEYCLOAK_SERVER_VERSION"
+  URL="https://github.com/keycloak/keycloak/releases/download/${KEYCLOAK_SERVER_VERSION}/keycloak-${KEYCLOAK_SERVER_VERSION}.tar.gz"
 else
   echo "Downloading nightly Keycloak release"
   URL="https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-999.0.0-SNAPSHOT.tar.gz"

--- a/.github/scripts/start-local-server.sh
+++ b/.github/scripts/start-local-server.sh
@@ -9,7 +9,8 @@ if [ "$1" = "extension" ]; then
   echo "Adding default providers when starting Keycloak server";
 
   if [ "$1" == "extension" ]; then
-    mvn -Dextension -DskipTests -B -Dnightly clean package
+    mvn_args="-s .github/maven-settings.xml"
+    mvn -Dextension -DskipTests -B -Dnightly $mvn_args clean package
     cp extension/user-storage-simple/target/user-storage-properties-example.jar $dist/providers
     cp extension/user-storage-jpa/conf/quarkus.properties $dist/conf
     cp extension/user-storage-jpa/target/user-storage-jpa-example.jar $dist/providers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   DEFAULT_JDK_VERSION: 17
   DEFAULT_JDK_DIST: temurin
+  KEYCLOAK_SERVER_VERSION: 22.0.5
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 _Red Hat build of Keycloak_ is an Open Source Identity and Access Management solution for modern Applications and Services.
 
 The quickstarts herein provided demonstrate securing applications with _Red Hat build of Keycloak_ using different programming languages (and frameworks) 
-and how to extend the server capabilities through a set of Java-based [Service Provider Interfaces(SPI)](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_developer_guide/index). 
+and how to extend the server capabilities through a set of Java-based [Service Provider Interfaces(SPI)](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_developer_guide/index). 
 They provide small, specific, working examples that can be used as a reference for your own project.
 
 They are organized in this repository under different categories (or directories) as follows:
@@ -34,6 +34,15 @@ First clone the quickstarts repository:
 
 Each quickstart provides its own documentation with the steps you need to follow in order to build, test, and run the example.
 Look at the `README.md` file at the root of a quickstart for more details.
+
+## Maven repository
+
+In order to use maven repository with the productized artifacts, it is needed to add repository https://maven.repository.redhat.com/ga/ to you settings.xml file.
+You can see this repository in the [maven-settings.xml file](.github/maven-settings.xml). You can either add the repository to your default `settings.xml` file
+,which is usually in `<your-home-dir>/.m2/settings.xml` file. Or you can run all the maven commands referred from individual quickstarts with the switch pointing to `maven-settings.xml` file:
+```
+mvn <other arguments as described in the specific quickstarts> -s <path to the file>/.github/maven-settings.xml
+```
 
 ### Chrome driver version
 

--- a/extension/user-storage-jpa/pom.xml
+++ b/extension/user-storage-jpa/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/extension/user-storage-simple/pom.xml
+++ b/extension/user-storage-simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/jaxrs-resource-server/README.md
+++ b/jakarta/jaxrs-resource-server/README.md
@@ -27,7 +27,7 @@ Starting and Configuring the Red Hat build of Keycloak Server
 -------------------
 
 To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
-[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/getting_started_guide/index.
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/getting_started_guide/index.
 
 For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
 
@@ -40,7 +40,7 @@ You should be able to access your _Red Hat build of Keycloak_ server at http://l
 Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
 
 Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+or more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
 
 Starting the JBoss EAP Server
 -------------------

--- a/jakarta/jaxrs-resource-server/pom.xml
+++ b/jakarta/jaxrs-resource-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jakarta/servlet-authz-client/README.md
+++ b/jakarta/servlet-authz-client/README.md
@@ -40,7 +40,7 @@ Starting and Configuring the Red Hat build of Keycloak Server
 -------------------
 
 To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
-[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/getting_started_guide/index.
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/getting_started_guide/index.
 
 For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
 
@@ -53,7 +53,7 @@ You should be able to access your _Red Hat build of Keycloak_ server at http://l
 Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
 
 Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
 
 Starting the JBoss EAP Server
 -------------------
@@ -136,5 +136,5 @@ References
 --------------------
 
 * [SSO With JBoss EAP](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/8-beta/html-single/using_single_sign-on_with_jboss_eap/index#doc-wrapper)
-* [Red Hat build of Keycloak Authorization Services](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/authorization_services_guide/index)
+* [Red Hat build of Keycloak Authorization Services](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/authorization_services_guide/index)
 * [Red Hat build of Keycloak Documentation](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/)

--- a/jakarta/servlet-authz-client/pom.xml
+++ b/jakarta/servlet-authz-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>jakarta-servlet-authz-client</artifactId>

--- a/js/spa/README.md
+++ b/js/spa/README.md
@@ -27,7 +27,7 @@ Starting and Configuring the Red Hat build of Keycloak Server
 -------------------
 
 To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
-[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/getting_started_guide/index.
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/getting_started_guide/index.
 
 For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
 
@@ -40,7 +40,7 @@ You should be able to access your _Red Hat build of Keycloak_ server at http://l
 Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
 
 Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
 
 Alternatively, you can create the realm using the following command (it might require first to run `npm install`):
 
@@ -112,5 +112,5 @@ npx playwright install
 References
 --------------------
 
-* [Red Hat build of Keycloak JavaScript Adapter](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/securing_applications_and_services_guide/index#_javascript_adapter)
+* [Red Hat build of Keycloak JavaScript Adapter](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/securing_applications_and_services_guide/index#_javascript_adapter)
 * [Red Hat build of Keycloak Documentation](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/)

--- a/js/spa/package.json
+++ b/js/spa/package.json
@@ -8,7 +8,7 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "^22.0.5",
     "express": "^4.18.2",
     "string-replace-middleware": "^1.0.2"
   },

--- a/nodejs/resource-server/README.md
+++ b/nodejs/resource-server/README.md
@@ -31,7 +31,7 @@ Starting and Configuring the Red Hat build of Keycloak Server
 -------------------
 
 To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
-[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/getting_started_guide/index.
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/getting_started_guide/index.
 
 For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
 
@@ -44,12 +44,21 @@ You should be able to access your _Red Hat build of Keycloak_ server at http://l
 Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
 
 Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
 
 Alternatively, you can create the realm using the following command (it might require first to run `npm install`):
 
 ```shell
 npm run create-realm
+```
+
+Use productized NodeJS adapter
+------------------------------
+In order to use productized _Red Hat build of Keycloak_ Node.js adapter, it is recommended to download it from the _Red Hat build of Keycloak_ official download pages.
+Afterwards, you can update `package.lock` file of the adapter to refer to the downloaded file. It can be changed to something like this (replace path with the actual path where you downloaded the file):
+
+```
+"keycloak-connect": "file:/<path-to-the-downloaded-file>/rhbk-22.0.6-nodejs-adapter.tar.gz"
 ```
 
 Build and Deploy the Quickstart
@@ -139,5 +148,5 @@ npx playwright install
 References
 --------------------
 
-* [Red Hat build of Keycloak Node.js Adapter](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/securing_applications_and_services_guide/index#_javascript_adapter)
+* [Red Hat build of Keycloak Node.js Adapter](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/securing_applications_and_services_guide/index#_javascript_adapter)
 * [Red Hat build of Keycloak Documentation](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/)

--- a/nodejs/resource-server/package.json
+++ b/nodejs/resource-server/package.json
@@ -8,9 +8,9 @@
     "delete-realm": "node scripts/delete-realm.js"
   },
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "https://github.com/keycloak/keycloak/releases/download/nightly/keycloak-admin-client-999.0.0-SNAPSHOT.tgz",
+    "@keycloak/keycloak-admin-client": "^22.0.5",
     "express": "^4.18.2",
-    "keycloak-connect": "https://github.com/keycloak/keycloak-nodejs-connect/releases/download/nightly/keycloak-nodejs-connect.tgz"
+    "keycloak-connect": "^22.0.5"
   },
   "devDependencies": {
     "keycloak-request-token": "^0.1.0"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.keycloak.quickstarts</groupId>
     <artifactId>keycloak-quickstart-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>22.0.6.redhat-00002</version>
     <packaging>pom</packaging>
     <name>Keycloak Quickstart: parent</name>
     <description>Parent</description>
@@ -36,6 +36,8 @@
 
     <properties>
         <version.keycloak>${project.version}</version.keycloak>
+        <quarkus.version>3.2.6.Final-redhat-00002</quarkus.version>
+
         <servlet.api.30.version>1.0.2.Final</servlet.api.30.version>
         <jboss-jaxrs-api_2.1_spec>1.0.1.Final</jboss-jaxrs-api_2.1_spec>
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
@@ -299,13 +301,6 @@
                                             <type>zip</type>
                                             <outputDirectory>target</outputDirectory>
                                         </artifactItem>
-                                        <artifactItem>
-                                            <groupId>org.keycloak</groupId>
-                                            <artifactId>keycloak-saml-wildfly-adapter-jakarta-dist</artifactId>
-                                            <version>${version.keycloak}</version>
-                                            <type>zip</type>
-                                            <outputDirectory>target/wildfly-${version.wildfly}</outputDirectory>
-                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>
@@ -437,6 +432,13 @@
                         <groupId>org.keycloak.bom</groupId>
                         <artifactId>keycloak-spi-bom</artifactId>
                         <version>${version.keycloak}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.redhat.quarkus.platform</groupId>
+                        <artifactId>quarkus-bom</artifactId>
+                        <version>${quarkus.version}</version>
                         <type>pom</type>
                         <scope>import</scope>
                     </dependency>

--- a/spring/rest-authz-resource-server/README.md
+++ b/spring/rest-authz-resource-server/README.md
@@ -29,7 +29,7 @@ Starting and Configuring the Red Hat build of Keycloak Server
 -------------------
 
 To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
-[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/getting_started_guide/index.
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/getting_started_guide/index.
 
 For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
 
@@ -42,7 +42,7 @@ You should be able to access your _Red Hat build of Keycloak_ server at http://l
 Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
 
 Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
-For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+For more details, see the _Red Hat build of Keycloak_ documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
 
 Build and Run the Quickstart
 -------------------------------
@@ -170,5 +170,5 @@ References
 --------------------
 
 * [Spring OAuth 2.0 Resource Server JWT](https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html)
-* [Red Hat build of Keycloak Authorization Services](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/authorization_services_guide/index)
+* [Red Hat build of Keycloak Authorization Services](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/html-single/authorization_services_guide/index)
 * [Red Hat build of Keycloak Documentation](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/22.0/)

--- a/spring/rest-authz-resource-server/pom.xml
+++ b/spring/rest-authz-resource-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.keycloak.quickstarts</groupId>
         <artifactId>keycloak-quickstart-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>22.0.6.redhat-00002</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- Updating version of Java adapters to and Keycloak dependencies to `22.0.6.redhat-00002`, which is the version corresponding to RHBK 22
- Keycloak server used in the tests is 22.0.5 (as the GH actions tests don't have access to the rhbk ZIP build)
- Documentation links fixed
- Instructions for nodeJS adapter for people to use the productized version of the adapter (but tests are using community one again due not possible to download productized build)
- Added quarkus bom to `pom.xml` to align dependencies
