### PR TITLE
24.x adding saml quickstart

### DIFF
--- a/jakarta/servlet-saml-service-provider/README.md
+++ b/jakarta/servlet-saml-service-provider/README.md
@@ -1,0 +1,106 @@
+servlet-saml-service-provider: Servlet SAML Service Provider
+=============================================================
+
+Level: Beginner
+Technologies: Jakarta EE
+Summary: JSP Profile Application
+Target Product: Red Hat build of Keycloak, <span>JBoss EAP</span>
+
+What is it?
+-----------
+
+This quickstart demonstrates how to protect a SAML Service Provider that authenticates using _Red Hat build of Keycloak_. 
+Once authenticated the application shows the users profile information.
+
+System Requirements
+-------------------
+
+To compile and run this quickstart you will need:
+
+* JDK 17
+* Apache Maven 3.8.6
+* JBoss EAP 8
+* Red Hat build of Keycloak 24+
+* Docker 20+
+
+Starting and Configuring the Keycloak Server
+-------------------
+
+To start a _Red Hat build of Keycloak_ Server you can use OpenJDK on Bare Metal, _Red Hat build of Keycloak_ Operator or any other option described in
+[Red Hat build of Keycloak Getting Started guides]https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/24.0/html-single/getting_started_guide/index.
+
+For example when using Bare metal, you need to have Java 17 or later available. Then you can unzip _Red Hat build of Keycloak_ distribution and in the directory `bin` run this command:
+
+```shell
+./kc.[sh|bat] start-dev --http-port=8180
+```
+
+You should be able to access your _Red Hat build of Keycloak_ server at http://localhost:8180.
+
+Log in as the admin user to access the _Red Hat build of Keycloak_ Administration Console. Username should be `admin` and password `admin`.
+
+Import the [realm configuration file](config/realm-import.json) to create a new realm called `quickstart`.
+For more details, see the Keycloak documentation about how to [create a new realm](https://access.redhat.com/documentation/en-us/red_hat_build_of_keycloak/24.0/html-single/server_administration_guide/index#proc-creating-a-realm_server_administration_guide).
+
+Starting the JBoss EAP Server
+-------------------
+
+In order to deploy the example application, you need a JBoss EAP Server up and running. For more details, see the JBoss EAP documentation about how
+to [install the server](https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.0/html-single/red_hat_jboss_enterprise_application_platform_installation_methods/index).
+
+Once you have JBoss EAP server downloaded somewhere, it is needed to install SAML adapter into it. It can be installed with the usage of Galleon tools. Please follow these instructions:
+
+1. Download JBoss EAP Installation Manager as described in the [EAP documentation](https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/8.0/html-single/red_hat_jboss_enterprise_application_platform_installation_methods/index#proc_downloading-and-installing-jboss-eap-installation-manager-cli-tool_default).
+
+2. Install Keycloak SAML adapter galleon feature pack into JBoss EAP via JBoss EAP Installation manager. It can be done for instance with the command similar to this from the
+directory of JBoss EAP Installation Manager (replace environment variables with the proper directories according to your environment):
+
+```
+cd $JBOSS_EAP_INSTALLATION_MANAGER/bin
+./jboss-eap-installation-manager.sh feature-pack add \
+  --fpl org.keycloak:keycloak-saml-adapter-galleon-pack \
+  --layers keycloak-client-saml \
+  --dir $JBOSS_EAP_DIR
+```
+
+3. Start JBoss EAP server and make sure the server is accessible from `localhost` and listening on port `8080`.
+
+Build and Deploy the Quickstart
+-------------------------------
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+
+2. The following shows the command to deploy the quickstart:
+
+   ````
+   mvn -Djakarta clean wildfly:deploy
+   ````
+
+Access the Quickstart
+----------------------
+
+You can access the application with the following URL: <http://localhost:8080/servlet-saml-service-provider>
+
+You should be able to authenticate using any of these users:
+
+| Username | Password | Roles              |
+|----------|----------|--------------------|
+| alice    | alice    | user               |
+
+Undeploy the Quickstart
+--------------------
+
+1. Open a terminal and navigate to the root directory of this quickstart.
+
+2. The following shows the command to undeploy the quickstart:
+
+````
+mvn -Djakarta clean wildfly:undeploy
+````
+
+References
+--------------------
+
+* [Keycloak SAML Adapter](https://www.keycloak.org/docs/latest/securing_apps/#_saml_jboss_adapter)
+* [Keycloak Documentation](https://www.keycloak.org/documentation)
+* [Wildfly SAML documentation](https://docs.wildfly.org/30/WildFly_Elytron_Security.html#Keycloak_SAML_Integration)

--- a/jakarta/servlet-saml-service-provider/config/realm-import.json
+++ b/jakarta/servlet-saml-service-provider/config/realm-import.json
@@ -1,0 +1,193 @@
+{
+  "realm": "quickstart",
+  "enabled": true,
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "email": "alice@keycloak.org",
+      "firstName": "Alice",
+      "lastName": "Liddel",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "alice"
+        }
+      ],
+      "realmRoles": [
+        "user",
+        "offline_access"
+      ],
+      "clientRoles": {
+        "account": [
+          "manage-account"
+        ]
+      }
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user",
+        "description": "User privileges"
+      }
+    ]
+  },
+  "clients": [ {
+    "clientId": "servlet-saml-service-provider",
+    "adminUrl": "http://localhost:8080/servlet-saml-service-provider/saml",
+    "baseUrl": "http://localhost:8080/servlet-saml-service-provider/",
+    "enabled": true,
+    "redirectUris": [
+      "http://localhost:8080/servlet-saml-service-provider/*"
+    ],
+    "frontchannelLogout": true,
+    "protocol": "saml",
+    "attributes": {
+      "saml.force.post.binding": "true",
+      "saml.server.signature": "true",
+      "saml.signing.certificate": "MIICrzCCAZcCBgFbFRHPvjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBhcHAtcHJvZmlsZS1zYW1sMB4XDTE3MDMyODEzMTcyMFoXDTI3MDMyODEzMTkwMFowGzEZMBcGA1UEAwwQYXBwLXByb2ZpbGUtc2FtbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMgOV7fWkvNePfHpcWVBwYgPIEV15hKFwPJ/7XcMwZNKjDJ7ft4kTPoKvZ4JGZEAukBbjvOcJkF0gacRgjDgp9pOu9YzZhi4MJwDzxZEEkLu7z2SD+boJEuP8ZCARcqliFLjQ5k3VwpFoAZ9kMOZekf8odObmB6x/EcOpfZDEtOdfpDXRw2S1qw/bKpbjcqKSz7u1O9C+Zr+Dw8v07JbVbP4rYr/8Bfq7vFcB30gf8YEI9nn6zR7MwRzrB2u4H4CrsLLv2BmLPGkuAEtYEoFhnn8vI4t4Xf9oIeeWAsJLrwK3LCnr8KpJhO+jkLBu+3ELy6mHGn3PkUXfGrAOwVLPz0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEABQMerrVDcvqaN+d2Fps7qTglLv2kJKSE/6qyisNUry2oDxIX8xnFVPZJRd1np6lwwbBSUK7vf9I1OWOxLTuI8Qa2b+0bEBYrqb00O2L9V5UUEE5/M1BbHKt4EL1L/UXYipwFfD6g5t3w3yd5zDVj6Z7OFXeYpNZMmOF0eUWG9GKRg8lcHPHMm98s3hY0DE+YEJ2cg73MZyom7h2PEhUUt1YgIe63avml+1DBXs3TSUJTngGG7rJGdDV3ZEMV6e45S0aBM78G3Ll1GwM2kDp6sWOHon7YYXqjCohWQPIoypikVKavQj6LV8v9EjVJ3hvGfnNiYefxC1fkPfwJjrtzQw==",
+      "saml.signature.algorithm": "RSA_SHA256",
+      "saml_force_name_id_format": "true",
+      "saml.client.signature": "true",
+      "saml.authnstatement": "true",
+      "saml.signing.private.key": "MIIEogIBAAKCAQEAyA5Xt9aS81498elxZUHBiA8gRXXmEoXA8n/tdwzBk0qMMnt+3iRM+gq9ngkZkQC6QFuO85wmQXSBpxGCMOCn2k671jNmGLgwnAPPFkQSQu7vPZIP5ugkS4/xkIBFyqWIUuNDmTdXCkWgBn2Qw5l6R/yh05uYHrH8Rw6l9kMS051+kNdHDZLWrD9sqluNyopLPu7U70L5mv4PDy/TsltVs/itiv/wF+ru8VwHfSB/xgQj2efrNHszBHOsHa7gfgKuwsu/YGYs8aS4AS1gSgWGefy8ji3hd/2gh55YCwkuvArcsKevwqkmE76OQsG77cQvLqYcafc+RRd8asA7BUs/PQIDAQABAoIBAELnMQSk+L30zWiCdk6zn+I9lMBF/mxBWNaAW8zNckssyhfz3uixYSDZyLH6PxeUE7WEKRllJhILwXQ60bxA1UGXxQ+MXt9zcaYrS+0ZVLYXq+B+YV0KU2EFwXZev3hWxXFa2Xd631vrDuo8wdX4FMHQRdo7lbLmOQUWbAAgTEKCOIKxHtZYqb+J3BK4g347SzYvKpvqXhavIpVRQm5vLYPrge1gE83jo9ag2uAHCHpeToaH1Bohp7/tu6MWCnKiL9GBY5Me/PLmY5nADLaGspndYVCaxJbRQyfX0KlKqqlj2LBlVZS9ojhnyZLxymrvNmtqrcrMoJPE15jF4v/sc40CgYEA7w567TMXAJDF9QwaHZ4ZJeQL365mtRiiQQpLok2eVIqlr/C4i7SqCs5C8QoA9by9I2Usa5EFEgKsme+W98pkNy1ynkYKDuzo57PMkNzHmsqLaqCsfY/zqdodrSVLoA9+nI82TCR7YKcZDpgpMa35mVdYQzbZIYWxnCpkfRGd6yMCgYEA1jw5XKa7zBtE0QByNpGV1zUVkl2qJZcrp6fA4syp5VxhC0IpYg1Qu6ZL0lSvYLfGGQiURLAXQAv1EtkTRv1ol3l859DxFrI4GWuNhH1zE6kuomT4zwhQTa8dZsCmuP3WdJKsOUaDwFTOf0u2Ik7o/zzmOpjiYsdk5vjeVPVsgh8CgYALdRE1Lx6qG0YxkWvrAXnJFB3xkYVApraYEWtAkyHEgYShYxMlNvpzXCFfNhCHto0GFkJDwYaRr2kgU5hTtfKJpnb42PiAcKBVAowKYVp7s7ts19iMiAqwmFCVzNTMDhIOZNrAWXtETZ3o0igfRmxRChuj1QwhDCxQBMQeLmr4KwKBgE3M4Sf8hQbCgGNGPjQC+t+Er6jPyxKLq5bfHPVAThK1Uai9BjpNi5wZ8D8Z8fa1xoMg0nd/W3Iu5XlKy+1j6a/YtruY7XTIlAbnQCV1SW1Ca2UeNh05b7BGf+7o16Mmy9LZ0SGbsg0Ov08LN8GN1p+ahiGRk+U7dDFM/7Dqz9URAoGAZZTcUxCT5SdkI0alHDBevpOsn7r04sTpH7xhlZACMlUsL3Lo6ZfedSoEJGLqM2ZODFxRHMvaI5fhI7dToLDctkyic1oPi/wM/lVl+XlnrE/PgPCQIuLIN+BfLCVWuqQL9nfbmkerKUK+W0irZTNSg3QYFBMKEA03GXt0gtvGaYE=",
+      "saml_name_id_format": "username",
+      "saml.onetimeuse.condition": "false",
+      "saml_signature_canonicalization_method": "http://www.w3.org/2001/10/xml-exc-c14n#"
+    },
+    "protocolMappers": [
+      {
+        "id": "3932ad95-05a2-4eec-b86a-9fbc7eeaab39",
+        "name": "full name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-full-name-mapper",
+        "consentRequired": true,
+        "consentText": "${fullName}",
+        "config": {
+          "id.token.claim": "true",
+          "access.token.claim": "true"
+        }
+      },
+      {
+        "id": "2abce6ab-945d-407b-a0c1-5d8d31a4e530",
+        "name": "family name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${familyName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "lastName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "family_name",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "faf8c4ac-e35a-4760-8206-48cc1563afc0",
+        "name": "role list",
+        "protocol": "saml",
+        "protocolMapper": "saml-role-list-mapper",
+        "consentRequired": false,
+        "config": {
+          "single": "false",
+          "attribute.nameformat": "Basic",
+          "attribute.name": "Role"
+        }
+      },
+      {
+        "id": "8edd6288-7f0b-4eb1-9e91-2635845b224d",
+        "name": "username",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${username}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "username",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "preferred_username",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "4a1b9b23-629d-4b27-bfe0-403798d971d1",
+        "name": "X500 surname",
+        "protocol": "saml",
+        "protocolMapper": "saml-user-property-mapper",
+        "consentRequired": true,
+        "consentText": "${familyName}",
+        "config": {
+          "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+          "user.attribute": "lastName",
+          "friendly.name": "surname",
+          "attribute.name": "urn:oid:2.5.4.4"
+        }
+      },
+      {
+        "id": "576b5470-4ceb-4c95-8ba8-e2c0f26300af",
+        "name": "X500 email",
+        "protocol": "saml",
+        "protocolMapper": "saml-user-property-mapper",
+        "consentRequired": true,
+        "consentText": "${email}",
+        "config": {
+          "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+          "user.attribute": "email",
+          "friendly.name": "email",
+          "attribute.name": "urn:oid:1.2.840.113549.1.9.1"
+        }
+      },
+      {
+        "id": "8f7311d8-b02d-4083-a785-badd07b2f44b",
+        "name": "X500 givenName",
+        "protocol": "saml",
+        "protocolMapper": "saml-user-property-mapper",
+        "consentRequired": true,
+        "consentText": "${givenName}",
+        "config": {
+          "attribute.nameformat": "urn:oasis:names:tc:SAML:2.0:attrname-format:uri",
+          "user.attribute": "firstName",
+          "friendly.name": "givenName",
+          "attribute.name": "urn:oid:2.5.4.42"
+        }
+      },
+      {
+        "id": "a00023a6-0dc1-46a5-a7c7-121b4c90d58a",
+        "name": "given name",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${givenName}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "firstName",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "given_name",
+          "jsonType.label": "String"
+        }
+      },
+      {
+        "id": "90f4fe53-59f0-4c67-a171-167a678c3533",
+        "name": "email",
+        "protocol": "openid-connect",
+        "protocolMapper": "oidc-usermodel-property-mapper",
+        "consentRequired": true,
+        "consentText": "${email}",
+        "config": {
+          "userinfo.token.claim": "true",
+          "user.attribute": "email",
+          "id.token.claim": "true",
+          "access.token.claim": "true",
+          "claim.name": "email",
+          "jsonType.label": "String"
+        }
+      }
+    ]
+  }
+  ]
+}

--- a/jakarta/servlet-saml-service-provider/pom.xml
+++ b/jakarta/servlet-saml-service-provider/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.keycloak.quickstarts</groupId>
+        <artifactId>keycloak-quickstart-parent</artifactId>
+        <version>24.0.5.redhat-00001</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>servlet-saml-service-provider</artifactId>
+    <packaging>war</packaging>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>3.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-core</artifactId>
+            <version>${version.keycloak}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-adapter-spi</artifactId>
+            <version>${version.keycloak}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-saml-adapter-api-public</artifactId>
+            <version>${version.keycloak}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-test-helper</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.graphene</groupId>
+            <artifactId>graphene-webdriver</artifactId>
+            <version>${arquillian-graphene.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.extension</groupId>
+            <artifactId>arquillian-phantom-driver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>${version.wildfly.arquillian.container}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>servlet-saml-service-provider</finalName>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jakarta/servlet-saml-service-provider/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
+++ b/jakarta/servlet-saml-service-provider/src/main/java/org/keycloak/quickstart/profilejee/Controller.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.quickstart.profilejee;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.keycloak.adapters.saml.SamlDeploymentContext;
+import org.keycloak.adapters.saml.SamlPrincipal;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.constants.ServiceUrlConstants;
+
+/**
+ * Controller simplifies access to the server environment from the JSP.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2015 Red Hat Inc.
+ */
+public class Controller {
+
+    public String getFirstName(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "givenName");
+    }
+
+    public String getLastName(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "surname");
+    }
+
+    public String getEmail(HttpServletRequest req) {
+        return getFriendlyAttrib(req, "email");
+    }
+
+    public String getUsername(HttpServletRequest req) {
+        return getAccount(req).getName();
+    }
+
+    private String getFriendlyAttrib(HttpServletRequest req, String attribName) {
+        SamlPrincipal principal = getAccount(req);
+        return principal.getFriendlyAttribute(attribName);
+    }
+
+    private SamlPrincipal getAccount(HttpServletRequest req) {
+        SamlPrincipal principal = (SamlPrincipal)req.getUserPrincipal();
+        return principal;
+    }
+
+    public boolean isLoggedIn(HttpServletRequest req) {
+        return getAccount(req) != null;
+    }
+
+    public String getAccountUri(HttpServletRequest req) {
+        String serverPath = findKeycloakServerPath(req);
+        String realm = findRealmName(req);
+        return KeycloakUriBuilder.fromUri(serverPath).path(ServiceUrlConstants.ACCOUNT_SERVICE_PATH)
+                .queryParam("referrer", "servlet-saml-service-provider").build(realm).toString();
+    }
+
+    // HACK: This is a really bad way to find the realm name, but I can't
+    //       figure out a better way to do it with the SAML adapter.  It parses
+    //       the URL specified in keycloak-saml-example.xml
+    private String findRealmName(HttpServletRequest req) {
+        String bindingUrl = getBindingUrl(req);
+        // bindingUrl looks like http://localhost:8080/realms/master/protocol/saml
+        int beginIndex = bindingUrl.indexOf("/realms/") + "/realms/".length();
+        return bindingUrl.substring(beginIndex, bindingUrl.indexOf('/', beginIndex));
+    }
+
+    private String findKeycloakServerPath(HttpServletRequest req) {
+        String bindingUrl = getBindingUrl(req);
+        // bindingUrl looks like http://localhost:8080/realms/master/protocol/saml
+        return bindingUrl.substring(0, bindingUrl.indexOf("/", bindingUrl.indexOf("//") + 2));
+    }
+
+    private String getBindingUrl(HttpServletRequest req) {
+        SamlDeploymentContext ctx = (SamlDeploymentContext)req.getServletContext().getAttribute(SamlDeploymentContext.class.getName());
+        return ctx.resolveDeployment(null).getIDP().getSingleSignOnService().getRequestBindingUrl();
+    }
+
+}

--- a/jakarta/servlet-saml-service-provider/src/main/webapp/WEB-INF/keycloak-saml.xml
+++ b/jakarta/servlet-saml-service-provider/src/main/webapp/WEB-INF/keycloak-saml.xml
@@ -1,0 +1,33 @@
+<keycloak-saml-adapter>
+    <SP entityID="servlet-saml-service-provider"
+        sslPolicy="EXTERNAL"
+        logoutPage="/index.jsp">
+        <Keys>
+            <Key signing="true">
+                <PrivateKeyPem>
+                    MIIEogIBAAKCAQEAyA5Xt9aS81498elxZUHBiA8gRXXmEoXA8n/tdwzBk0qMMnt+3iRM+gq9ngkZkQC6QFuO85wmQXSBpxGCMOCn2k671jNmGLgwnAPPFkQSQu7vPZIP5ugkS4/xkIBFyqWIUuNDmTdXCkWgBn2Qw5l6R/yh05uYHrH8Rw6l9kMS051+kNdHDZLWrD9sqluNyopLPu7U70L5mv4PDy/TsltVs/itiv/wF+ru8VwHfSB/xgQj2efrNHszBHOsHa7gfgKuwsu/YGYs8aS4AS1gSgWGefy8ji3hd/2gh55YCwkuvArcsKevwqkmE76OQsG77cQvLqYcafc+RRd8asA7BUs/PQIDAQABAoIBAELnMQSk+L30zWiCdk6zn+I9lMBF/mxBWNaAW8zNckssyhfz3uixYSDZyLH6PxeUE7WEKRllJhILwXQ60bxA1UGXxQ+MXt9zcaYrS+0ZVLYXq+B+YV0KU2EFwXZev3hWxXFa2Xd631vrDuo8wdX4FMHQRdo7lbLmOQUWbAAgTEKCOIKxHtZYqb+J3BK4g347SzYvKpvqXhavIpVRQm5vLYPrge1gE83jo9ag2uAHCHpeToaH1Bohp7/tu6MWCnKiL9GBY5Me/PLmY5nADLaGspndYVCaxJbRQyfX0KlKqqlj2LBlVZS9ojhnyZLxymrvNmtqrcrMoJPE15jF4v/sc40CgYEA7w567TMXAJDF9QwaHZ4ZJeQL365mtRiiQQpLok2eVIqlr/C4i7SqCs5C8QoA9by9I2Usa5EFEgKsme+W98pkNy1ynkYKDuzo57PMkNzHmsqLaqCsfY/zqdodrSVLoA9+nI82TCR7YKcZDpgpMa35mVdYQzbZIYWxnCpkfRGd6yMCgYEA1jw5XKa7zBtE0QByNpGV1zUVkl2qJZcrp6fA4syp5VxhC0IpYg1Qu6ZL0lSvYLfGGQiURLAXQAv1EtkTRv1ol3l859DxFrI4GWuNhH1zE6kuomT4zwhQTa8dZsCmuP3WdJKsOUaDwFTOf0u2Ik7o/zzmOpjiYsdk5vjeVPVsgh8CgYALdRE1Lx6qG0YxkWvrAXnJFB3xkYVApraYEWtAkyHEgYShYxMlNvpzXCFfNhCHto0GFkJDwYaRr2kgU5hTtfKJpnb42PiAcKBVAowKYVp7s7ts19iMiAqwmFCVzNTMDhIOZNrAWXtETZ3o0igfRmxRChuj1QwhDCxQBMQeLmr4KwKBgE3M4Sf8hQbCgGNGPjQC+t+Er6jPyxKLq5bfHPVAThK1Uai9BjpNi5wZ8D8Z8fa1xoMg0nd/W3Iu5XlKy+1j6a/YtruY7XTIlAbnQCV1SW1Ca2UeNh05b7BGf+7o16Mmy9LZ0SGbsg0Ov08LN8GN1p+ahiGRk+U7dDFM/7Dqz9URAoGAZZTcUxCT5SdkI0alHDBevpOsn7r04sTpH7xhlZACMlUsL3Lo6ZfedSoEJGLqM2ZODFxRHMvaI5fhI7dToLDctkyic1oPi/wM/lVl+XlnrE/PgPCQIuLIN+BfLCVWuqQL9nfbmkerKUK+W0irZTNSg3QYFBMKEA03GXt0gtvGaYE=
+                </PrivateKeyPem>
+                <CertificatePem>
+                    MIICrzCCAZcCBgFbFRHPvjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBhcHAtcHJvZmlsZS1zYW1sMB4XDTE3MDMyODEzMTcyMFoXDTI3MDMyODEzMTkwMFowGzEZMBcGA1UEAwwQYXBwLXByb2ZpbGUtc2FtbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMgOV7fWkvNePfHpcWVBwYgPIEV15hKFwPJ/7XcMwZNKjDJ7ft4kTPoKvZ4JGZEAukBbjvOcJkF0gacRgjDgp9pOu9YzZhi4MJwDzxZEEkLu7z2SD+boJEuP8ZCARcqliFLjQ5k3VwpFoAZ9kMOZekf8odObmB6x/EcOpfZDEtOdfpDXRw2S1qw/bKpbjcqKSz7u1O9C+Zr+Dw8v07JbVbP4rYr/8Bfq7vFcB30gf8YEI9nn6zR7MwRzrB2u4H4CrsLLv2BmLPGkuAEtYEoFhnn8vI4t4Xf9oIeeWAsJLrwK3LCnr8KpJhO+jkLBu+3ELy6mHGn3PkUXfGrAOwVLPz0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEABQMerrVDcvqaN+d2Fps7qTglLv2kJKSE/6qyisNUry2oDxIX8xnFVPZJRd1np6lwwbBSUK7vf9I1OWOxLTuI8Qa2b+0bEBYrqb00O2L9V5UUEE5/M1BbHKt4EL1L/UXYipwFfD6g5t3w3yd5zDVj6Z7OFXeYpNZMmOF0eUWG9GKRg8lcHPHMm98s3hY0DE+YEJ2cg73MZyom7h2PEhUUt1YgIe63avml+1DBXs3TSUJTngGG7rJGdDV3ZEMV6e45S0aBM78G3Ll1GwM2kDp6sWOHon7YYXqjCohWQPIoypikVKavQj6LV8v9EjVJ3hvGfnNiYefxC1fkPfwJjrtzQw==
+                </CertificatePem>
+            </Key>
+        </Keys>
+        <IDP entityID="idp"
+             signatureAlgorithm="RSA_SHA256"
+             signatureCanonicalizationMethod="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <SingleSignOnService signRequest="true"
+                                 validateResponseSignature="true"
+                                 validateAssertionSignature="false"
+                                 requestBinding="POST"
+                                 bindingUrl="http://localhost:8180/realms/quickstart/protocol/saml"/>
+            <SingleLogoutService signRequest="true"
+                                 signResponse="true"
+                                 validateRequestSignature="true"
+                                 validateResponseSignature="true"
+                                 requestBinding="POST"
+                                 responseBinding="POST"
+                                 postBindingUrl="http://localhost:8180/realms/quickstart/protocol/saml"
+                                 redirectBindingUrl="http://localhost:8180/realms/quickstart/protocol/saml"/>
+        </IDP>
+    </SP>
+</keycloak-saml-adapter>

--- a/jakarta/servlet-saml-service-provider/src/main/webapp/WEB-INF/web.xml
+++ b/jakarta/servlet-saml-service-provider/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app
+        xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+        version="6.0">
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>app</web-resource-name>
+            <url-pattern>/profile.jsp</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>KEYCLOAK-SAML</auth-method>
+    </login-config>
+
+    <security-role>
+        <role-name>user</role-name>
+    </security-role>
+</web-app>

--- a/jakarta/servlet-saml-service-provider/src/main/webapp/index.jsp
+++ b/jakarta/servlet-saml-service-provider/src/main/webapp/index.jsp
@@ -1,0 +1,46 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak Example App</title>
+
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        
+        <c:set var="isLoggedIn" value="<%=controller.isLoggedIn(request)%>"/>
+        <c:if test="${isLoggedIn}">
+            <c:redirect url="profile.jsp"/>
+        </c:if>
+
+        <div class="wrapper" id="welcome">
+            <div class="menu">
+                <button name="loginBtn" onclick="location.href = 'profile.jsp'" type="button">Login</button>
+            </div>
+
+            <div class="content">
+                <div class="message">Please login</div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/jakarta/servlet-saml-service-provider/src/main/webapp/profile.jsp
+++ b/jakarta/servlet-saml-service-provider/src/main/webapp/profile.jsp
@@ -1,0 +1,62 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<%@page contentType="text/html" pageEncoding="ISO-8859-1"%>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+        <title>Keycloak SAML Example App</title>
+        <link rel="stylesheet" type="text/css" href="styles.css"/>
+    </head>
+    <body>
+        <jsp:useBean id="controller" class="org.keycloak.quickstart.profilejee.Controller" scope="request"/>
+        <c:set var="accountUri" value="<%=controller.getAccountUri(request)%>"/>
+        <c:set var="req" value="<%=request%>"/>
+
+        <div class="wrapper" id="profile">
+            <div class="menu">
+                <button name="logoutBtn" onclick="location.href = '?GLO=true'" type="button">Logout</button>
+                <button name="accountBtn" onclick="location.href = '${accountUri}'" type="button">Account</button>
+            </div>
+
+            <div class="content">
+                <div id="profile-content" class="message">
+                    <table cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="label">First name</td>
+                            <td><span id="firstName">${controller.getFirstName(req)}</span></td>
+                        </tr>
+                        <tr class="even">
+                            <td class="label">Last name</td>
+                            <td><span id="lastName">${controller.getLastName(req)}</span></td>
+                        </tr>
+                        <tr>
+                            <td class="label">Username</td>
+                            <td><span id="username">${controller.getUsername(req)}</span></td>
+                        </tr>
+                        <tr class="even">
+                            <td class="label">Email</td>
+                            <td><span id="email">${controller.getEmail(req)}</span></td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/jakarta/servlet-saml-service-provider/src/main/webapp/styles.css
+++ b/jakarta/servlet-saml-service-provider/src/main/webapp/styles.css
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+body {
+    background-color: #333;
+    font-family: sans-serif;
+    font-size: 30px;
+}
+
+button {
+    font-family: sans-serif;
+    font-size: 30px;
+    width: 200px;
+
+    background-color: #0085cf;
+    background-image: linear-gradient(to bottom, #00a8e1 0%, #0085cf 100%);
+    background-repeat: repeat-x;
+
+    border: 2px solid #ccc;
+    color: #fff;
+
+    text-transform: uppercase;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+button:hover {
+    background-color: #006ba6;
+    background-image: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
+}
+
+hr {
+    border: none;
+    background-color: #eee;
+    height: 10px;
+}
+
+.menu {
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.content {
+    background-color: #eee;
+    border: 1px solid #ccc;
+    padding: 10px;
+
+    -webkit-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    -moz-box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+    box-shadow: 2px 2px 10px 0px rgba(0,0,0,0.5);
+}
+
+.content .message {
+    padding: 10px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    font-size: 40px;
+}
+
+#token-content {
+    font-size: 20px;
+    padding: 5px;
+    white-space: pre;
+    text-transform: none;
+}
+
+.wrapper {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    bottom: 10px;
+    right: 10px;
+}
+
+.error {
+    color: #a21e22;
+}
+
+table {
+    width: 100%;
+}
+
+tr.even {
+    background-color: #eee;
+}
+
+td {
+    padding: 5px;
+}
+
+td.label {
+    font-weight: bold;
+    width: 250px;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <version.json.javax>1.1.2</version.json.javax>
         <version.yasson>1.0.8</version.yasson>
         <version.jackson>2.14.2</version.jackson>
+        <org.jboss.galleon.version>5.2.2.Final</org.jboss.galleon.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -184,6 +185,7 @@
             <modules>
                 <module>jakarta/servlet-authz-client</module>
                 <module>jakarta/jaxrs-resource-server</module>
+                <module>jakarta/servlet-saml-service-provider</module>
             </modules>
             <dependencyManagement>
                 <dependencies>
@@ -307,22 +309,51 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>${version.antrun.maven.plugin}</version>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <version>${org.jboss.galleon.version}</version>
+                        <!--Provision a server with relevant layers-->
                         <executions>
                             <execution>
-                                <id>install-adapters</id>
+                                <id>saml-adapter-installation</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
-                                    <goal>run</goal>
+                                    <goal>provision</goal>
                                 </goals>
                                 <configuration>
-                                    <target name="run">
-                                        <exec dir="target/wildfly-${version.wildfly}/bin" executable="${jboss-cli.executable}" inputstring="">
-                                            <arg value="--file=adapter-elytron-install-saml-offline.cli" />
-                                        </exec>
-                                    </target>
+                                    <install-dir>target/wildfly-${version.wildfly}</install-dir>
+                                    <record-state>true</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>false</offline>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>org.keycloak</groupId>
+                                            <artifactId>keycloak-saml-adapter-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <pluginOptions>
+                                        <optional-packages>all</optional-packages>
+                                    </pluginOptions>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>core-server</layer>
+                                                <layer>web-server</layer>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>datasources-web-server</layer>
+                                                <layer>web-console</layer>
+
+                                                <layer>keycloak-saml</layer>
+                                                <layer>keycloak-client-saml</layer>
+                                                <layer>keycloak-client-saml-ejb</layer>
+                                                <layer>elytron</layer>
+                                                <layer>elytron-oidc-client</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Adding SAML quickstart to RHBK 24 quickstarts. Marking as draft for now because it requires https://issues.redhat.com/browse/RHBK-1651 to be addressed first. Some RHBK artifacts need to be available in the RedHat Maven repository. Until they are available, this SAML quickstart won't work

